### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/packages/web/src/modules/di/module.ts
+++ b/packages/web/src/modules/di/module.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import { defineNuxtModule } from '@nuxt/kit';
 import { setupNuxtModule } from '../../utils/nuxt-module';
 import { generateInjectables } from './utils/generate-injectables';
@@ -8,6 +9,7 @@ export default defineNuxtModule({
 
     generateInjectables();
     nuxt.hook('builder:watch', (_event, path) => {
+      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
       if (path.startsWith('generated')) return;
       generateInjectables();
     });

--- a/packages/web/src/modules/trpc/module.ts
+++ b/packages/web/src/modules/trpc/module.ts
@@ -1,5 +1,5 @@
 import { addServerHandler, defineNuxtModule } from '@nuxt/kit';
-import { resolve } from 'pathe';
+import { relative, resolve } from 'pathe';
 import { setupNuxtModule } from '../../utils/nuxt-module';
 import { generateTrpcRouter } from './utils/generate-trpc-router';
 
@@ -14,6 +14,7 @@ export default defineNuxtModule({
 
     generateTrpcRouter();
     nuxt.hook('builder:watch', (_event, path) => {
+      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
       if (path.startsWith('generated')) return;
       generateTrpcRouter();
     });

--- a/packages/web/src/utils/nuxt-module.ts
+++ b/packages/web/src/utils/nuxt-module.ts
@@ -1,7 +1,7 @@
 import { addComponentsDir, addImportsDir, addPlugin } from '@nuxt/kit';
 import { Nuxt } from '@nuxt/schema';
 import fs from 'fs-extra';
-import { resolve } from 'pathe';
+import { relative, resolve } from 'pathe';
 
 export const setupNuxtModule = (name: string, nuxt: Nuxt) => {
   const dirname = resolve(process.cwd(), 'src/modules', name);
@@ -36,6 +36,7 @@ export const setupNuxtModule = (name: string, nuxt: Nuxt) => {
   };
 
   nuxt.hook('builder:watch', (_event, path) => {
+    path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
     if (path.startsWith('generated')) return;
     handleAutoImports();
   });


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

